### PR TITLE
Add playlist actions to the items in the cover view

### DIFF
--- a/cmd/tchaik/ui/static/js/src/components/Covers.js
+++ b/cmd/tchaik/ui/static/js/src/components/Covers.js
@@ -4,6 +4,7 @@
 var React = require('react/addons');
 
 var ArtworkImage = require('./ArtworkImage.js');
+var Icon = require('./Icon.js');
 
 var CollectionStore = require('../stores/CollectionStore.js');
 var CollectionActions = require('../actions/CollectionActions.js');
@@ -65,6 +66,10 @@ var Cover = React.createClass({
     return (
       <div className="cover">
         <ArtworkImage path={"/artwork/"+this.state.item.TrackID} />
+          <span className="controls">
+            <Icon icon="play" title="Play Now" onClick={this._onPlayNow} />
+            <Icon icon="list" title="Queue" onClick={this._onQueue} />
+          </span>
       </div>
     );
   },
@@ -76,6 +81,16 @@ var Cover = React.createClass({
         item: item,
       });
     }
+  },
+
+  _onPlayNow: function(e) {
+    e.stopPropagation();
+    CollectionActions.playNow(this.props.path);
+  },
+
+  _onQueue: function(e) {
+    e.stopPropagation();
+    CollectionActions.appendToPlaylist(this.props.path);
   },
 });
 

--- a/cmd/tchaik/ui/static/js/src/components/Covers.js
+++ b/cmd/tchaik/ui/static/js/src/components/Covers.js
@@ -58,7 +58,6 @@ var Cover = React.createClass({
   getInitialState: function() {
     return {
       item: this.props.item,
-      expanded: false,
     };
   },
 

--- a/cmd/tchaik/ui/static/js/src/components/Covers.js
+++ b/cmd/tchaik/ui/static/js/src/components/Covers.js
@@ -46,8 +46,18 @@ var Covers = React.createClass({
 });
 
 var Cover = React.createClass({
+  componentDidMount: function() {
+    CollectionStore.addChangeListener(this._onChange);
+    CollectionActions.fetch(this.props.path);
+  },
+
+  componentWillUnmount: function() {
+    CollectionStore.removeChangeListener(this._onChange);
+  },
+
   getInitialState: function() {
     return {
+      item: this.props.item,
       expanded: false,
     };
   },
@@ -55,9 +65,18 @@ var Cover = React.createClass({
   render: function() {
     return (
       <div className="cover">
-        <ArtworkImage path={"/artwork/"+this.props.item.TrackID} />
+        <ArtworkImage path={"/artwork/"+this.state.item.TrackID} />
       </div>
     );
+  },
+
+  _onChange: function(keyPath) {
+    if (keyPath == CollectionStore.pathToKey(this.props.path)) {
+      var item = CollectionStore.getCollection(this.props.path);
+      this.setState({
+        item: item,
+      });
+    }
   },
 });
 

--- a/cmd/tchaik/ui/static/sass/screen.scss
+++ b/cmd/tchaik/ui/static/sass/screen.scss
@@ -728,9 +728,36 @@ div#container {
       border-color: #666;
       background-color: #555;
       display: flex;
+      position: relative;
+
+      .controls {
+        display: none;
+
+        background-color: rgba(17, 17, 17, 0.9);
+        border-radius: 5px;
+        left: 50%;
+        padding: 5px;
+        position: absolute;
+        top: 80%;
+        transform: translate(-50%, -50%);
+
+        span.glyphicon {
+          padding-left: 5px;
+          padding-right: 5px;
+          color: #666;
+
+          &:hover {
+            color: white;
+          }
+        }
+      }
 
       &:hover {
         background-color: #777;
+
+        .controls {
+          display: block;
+        }
       };
 
       span.name {


### PR DESCRIPTION
This fixes the cover view (it was broken), and it adds playlist actions to the cover view. Like normal, you can either 'play', or 'queue' the entire album.

![covers](https://cloud.githubusercontent.com/assets/236589/7536629/d6e932f2-f5d4-11e4-93fa-742f8bb6db27.png)
... Ignore the missing covers, they're simply albums I don't have cover images for, but you can see on the top left cover I have the controls visible.