### PR TITLE
Replace onMouseDown event handlers with onClick event handler

### DIFF
--- a/cmd/tchaik/ui/static/js/src/components/LeftColumn.js
+++ b/cmd/tchaik/ui/static/js/src/components/LeftColumn.js
@@ -180,11 +180,11 @@ var Volume = React.createClass({
     var h = this.props.height - parseInt(volume * this.props.height);
     return (
       <div className="volume" onWheel={this._onWheel} >
-        <div className="bar" onMouseDown={this._onMouseDown} style={{height: this.props.height}}>
+        <div className="bar" onClick={this._onClick} style={{height: this.props.height}}>
           <div className="current" style={{height: h}} />
           <div className="marker" style={{height: this.props.markerHeight}} />
         </div>
-        <Icon icon={'volume-' + classSuffix} onMouseDown={this._toggleMute} />
+        <Icon icon={'volume-' + classSuffix} onClick={this._toggleMute} />
       </div>
     );
   },
@@ -205,7 +205,7 @@ var Volume = React.createClass({
     VolumeActions.volume(v);
   },
 
-  _onMouseDown: function(evt) {
+  _onClick: function(evt) {
     var pos = evt.pageY - _getOffsetTop(evt.currentTarget);
     var height = evt.currentTarget.offsetHeight;
     VolumeActions.volume(1 - pos/height);

--- a/cmd/tchaik/ui/static/js/src/components/LeftColumn.js
+++ b/cmd/tchaik/ui/static/js/src/components/LeftColumn.js
@@ -180,7 +180,7 @@ var Volume = React.createClass({
     var h = this.props.height - parseInt(volume * this.props.height);
     return (
       <div className="volume" onWheel={this._onWheel} >
-        <div className="bar" onMouseOver={this._onMouseOver} onMouseDown={this._onMouseDown} style={{height: this.props.height}}>
+        <div className="bar" onMouseDown={this._onMouseDown} style={{height: this.props.height}}>
           <div className="current" style={{height: h}} />
           <div className="marker" style={{height: this.props.markerHeight}} />
         </div>

--- a/cmd/tchaik/ui/static/js/src/components/NowPlaying.js
+++ b/cmd/tchaik/ui/static/js/src/components/NowPlaying.js
@@ -119,12 +119,9 @@ var PlayProgress = React.createClass({
   },
 
   _onClick: function(evt) {
-    // Only proceed on left mouse button clicks.
-    if (evt.button === 0) {
-      var pos = evt.pageX - _getOffsetLeft(evt.currentTarget);
-      var width = evt.currentTarget.offsetWidth;
-      this.props.setCurrentTime((pos / width) * this.props.duration);
-    }
+    var pos = evt.pageX - _getOffsetLeft(evt.currentTarget);
+    var width = evt.currentTarget.offsetWidth;
+    this.props.setCurrentTime((pos / width) * this.props.duration);
   },
 
   _onWheel: function(evt) {

--- a/cmd/tchaik/ui/static/js/src/components/NowPlaying.js
+++ b/cmd/tchaik/ui/static/js/src/components/NowPlaying.js
@@ -108,7 +108,7 @@ var PlayProgress = React.createClass({
     var b = "calc("+Math.min(bpc, 100.0)+"% - " + this.props.markerWidth + "px)";
 
     return (
-      <div className="playProgress" onMouseDown={this._onMouseDown} onWheel={this._onWheel}>
+      <div className="playProgress" onClick={this._onClick} onWheel={this._onWheel}>
         <div className="bar">
           <div className="current" style={{width: w}} />
           <div className="marker" style={{width: this.props.markerWidth}} />
@@ -118,7 +118,7 @@ var PlayProgress = React.createClass({
     );
   },
 
-  _onMouseDown: function(evt) {
+  _onClick: function(evt) {
     // Only proceed on left mouse button clicks.
     if (evt.button === 0) {
       var pos = evt.pageX - _getOffsetLeft(evt.currentTarget);


### PR DESCRIPTION
onClick is only fired when a left click has been fully triggered.

Using onMouseDown causes a few issues
 - It's fired for both left clicks and right clicks
 - Actions aren't normally triggered when the user presses the mouse button. Try clicking on buttons around the web, but then dragging your mouse away from the button before releasing it. You will find that the button would not have triggered it's event.
